### PR TITLE
Some fixes for multiple content assign to single user

### DIFF
--- a/src/administrator/includes/rbacl.php
+++ b/src/administrator/includes/rbacl.php
@@ -129,7 +129,9 @@ class RBACL
 					$userModel = self::model("user");
 					$contentRoleId = $userModel->getAssociatedContentRole($userId, $client, $contentId);
 
-					if (in_array($contentRoleId, $allowedRoles))
+					$rolesAllowed = array_intersect($contentRoleId, $allowedRoles);
+
+					if (!empty($rolesAllowed))
 					{
 						return true;
 					}

--- a/src/administrator/models/user.php
+++ b/src/administrator/models/user.php
@@ -106,7 +106,7 @@ class SubusersModelUser extends AdminModel
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function getAssociatedContentRole($userId, $client, $contentId)
+	public function getAssociatedContentRole($userId, $client, $contentId = null)
 	{
 		$db = Factory::getDbo();
 		$query = $db->getQuery(true);
@@ -115,9 +115,14 @@ class SubusersModelUser extends AdminModel
 		$query->from($db->quoteName('#__tjsu_users'));
 		$query->where($db->quoteName('user_id') . " = " . (int) $userId);
 		$query->where($db->quoteName('client') . " = " . $db->q($client));
-		$query->where($db->quoteName('client_id') . " = " . (int) $contentId);
+
+		if (!is_null($contentId))
+		{
+			$query->where($db->quoteName('client_id') . " = " . $db->quote($contentId));
+		}
+
 		$db->setQuery($query);
 
-		return $db->loadResult();
+		return $db->loadColumn();
 	}
 }


### PR DESCRIPTION
1. src/administrator/includes/rbacl.php
In this file, I have added array_intersect in check function, because when multiple client_id assign to a single user then only first client_id check. need to check all roles across the system.
2. src/administrator/models/user.php
In this file two changes needed 
2.a) In getTable table add table file
2.b) In getAssociatedContentRole function contentId variable make optional and changed query result to get all role column result.